### PR TITLE
Add NVIDIA Image for GPU CI via Cirun.io

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,14 +1,17 @@
-# Self-Hosted Github Action Runners on GCP via Cirun.io
+# Self-Hosted Github Action Runners on AWS via Cirun.io
 # Reference: https://docs.cirun.io/reference/yaml.html
 runners:
   - name: gpu-runner
+    # Cloud Provider: AWS
     cloud: aws
-    region: eu-west-1
-    instance_type: g4dn.xlarge  # Cheapest VM on AWS
-    gpu: true
-    machine_image: ami-03caf24deed650e2c  # Ubuntu 20.04 in eu-west-1
+    instance_type: g4dn.xlarge
+    # NVIDIA Deep Learning AMI from AWS Marketplace
+    # https://aws.amazon.com/marketplace/pp/prodview-e7zxdqduz4cbs
+    machine_image: ami-00ac0c28c01352e53
+    # preemptible instances seems quite less reliable.
     preemptible: false
+    # Path of the relevant workflow file
     workflow: .github/workflows/tests-gpu.yml
+    # Number of runners to provision on every trigger on Actions job
+    # See .github/workflows/tests-gpu.yml
     count: 1
-    labels:
-      - gpu

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -1,8 +1,8 @@
+name: Tests on GPU
 # The name is short because we mostly care how it appears in the pull request
 # "checks" dialogue box - it looks like
 #     Tests on GPU / ubuntu-latest, python-3.9, defaults
 # or similar.
-name: Tests on GPU
 
 on:
     [push, pull_request]
@@ -18,7 +18,7 @@ defaults:
 jobs:
   cases:
     name: ${{ matrix.os }}, ${{ matrix.case-name }}
-    runs-on: [self-hosted, gpu]
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
@@ -29,10 +29,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - name: Setup Python
+        uses: conda-incubator/setup-miniconda@v2
+        env:
+          CONDA: /home/runnerx/miniconda3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+          miniconda-version: "latest"
 
       - name: Install QuTiP from GitHub
         run: |


### PR DESCRIPTION
- [x] Add Nvidia image from AWS
- [x] Fix workflow name
- [x] Fix setting up python

Documentation for custom images:
https://docs.cirun.io/cloud/custom_images.html#aws-custom-ami